### PR TITLE
Allowing all 2xx status codes

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -122,8 +122,8 @@ PlexAPI.prototype._request = function _request(relativeUrl, method, parseRespons
             );
         }
 
-        if (response.statusCode !== 200) {
-            return deferred.reject(new Error('Plex Server didnt respond with status code 200, response code: ' + response.statusCode));
+        if (response.statusCode < 200 || response.statusCode > 299) {
+            return deferred.reject(new Error('Plex Server didnt respond with a valid 2xx status code, response code: ' + response.statusCode));
         }
 
         // prevent holding an open http agent connection by pretending to consume data,


### PR DESCRIPTION
Allowing all 2xx status codes as Plex.tv can also respond with at least
a 201 status (valid)
